### PR TITLE
Add auto-changelog packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@babel/preset-typescript": "7.9.0",
     "@types/jest": "25.2.3",
     "@types/node": "14.0.5",
+    "auto-changelog": "^1.16.2",
     "babel-jest": "26.0.1",
     "jest": "26.0.1",
     "prettier": "2.0.5",
@@ -48,6 +49,7 @@
     "type": "tsc --noEmit",
     "test": "YYY_TEST=leak jest --verbose",
     "build": "babel src --extensions \".ts\" --out-dir  lib --ignore \"**/__tests__/\",\"**/__fixtures__/\" && cp src/cli lib/",
-    "lint": "yarn prettier -c '**/*.{ts,tsx,js,jsx,json,md}' '!lib/**'"
+    "lint": "yarn prettier -c '**/*.{ts,tsx,js,jsx,json,md}' '!lib/**'",
+    "version": "auto-changelog -p && git add CHANGELOG.md"
   }
 }


### PR DESCRIPTION
This packages manages a changelog.md file automatically, each time you triggers `npm  version` in order to bump a version it will run and calculate the changes from new version just created to the last, and log them.
Check [auto-changelog](https://github.com/CookPete/auto-changelog/blob/master/CHANGELOG.md) repo