### PR TITLE
fix: publish only lib folder + npm relevant files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,9 +48,7 @@ jobs:
 
       - run: yarn install --frozen-lockfile
       - run: yarn build
-      - run: mkdir npm-dist ; cp -r CHANGELOG.md README.md package.json yarn.lock lib/ npm-dist/
       - uses: JS-DevTools/npm-publish@v1.4.0
         if: success() && github.ref == 'refs/heads/master'
         with:
           token: ${{ secrets.NPM_TOKEN }}
-          package: npm-dist/package.json

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "github-secret": "./lib/cli/bin",
     "github-secret-dotenv": "./lib/cli/bin"
   },
+  "files": [
+    "lib/**/*.*"
+  ],
   "scripts": {
     "type": "tsc --noEmit",
     "test": "YYY_TEST=leak jest --verbose",


### PR DESCRIPTION
Your publish process breaking the package structure.

I've run locally `npm pack --dry-run` which simulate all the files which will be packed.
![image](https://user-images.githubusercontent.com/9304194/102708442-d4163c80-42ab-11eb-8681-983cf4e029ad.png)

I think that it solves the #9  as well
