### PR TITLE
Improve TS code generation to support node > 12.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "ts-node": "9.1.1",
     "typescript": "4.1.3"
   },
+  "engines": {
+    "node": ">12"
+  },
   "bin": {
     "github-secret": "./lib/cli/bin",
     "github-secret-dotenv": "./lib/cli/bin"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,14 @@
 {
   "compilerOptions": {
     "moduleResolution": "node",
-    "target": "es5",
+    "target": "es2019",
+    "lib": [
+      "es2019",
+      "es2020.bigint",
+      "es2020.string",
+      "es2020.symbol.wellknown"
+    ],
+    "module": "commonjs",
     "skipLibCheck": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Since this is a Node lib, it is better to specify target TS to the relevant node version (from you workflow files it is v12) to prevent redundant transpilation of Promise, and other native supported syntax.

Based on https://stackoverflow.com/questions/59787574/typescript-tsconfig-settings-for-node-js-12/59787575#59787575